### PR TITLE
Fix TgCrypto installation while running in Docker container on Ubuntu…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.11.5-alpine3.18
+FROM python:3.11.10-alpine3.20
+
+RUN apk add gcc musl-dev
 
 WORKDIR app/
 


### PR DESCRIPTION
TgCrypto installation fails on Ubuntu minimal (and probably other minimal systems) while running inside docker where python 3.11 alpine and other slim python images don't include the gcc compiler. 

musl-dev is also required by gcc. [Source](https://wiki.alpinelinux.org/wiki/GCC)